### PR TITLE
fix: 관리자-유저 목록 조회 (기본 정보 조회, 특정 유저의 대여&예약 목록 조회)

### DIFF
--- a/src/main/java/green/mtcoding/bookbox/admin/AdminController.java
+++ b/src/main/java/green/mtcoding/bookbox/admin/AdminController.java
@@ -28,7 +28,7 @@ public class AdminController {
 
         return ResponseEntity.ok()
                 .header("Authorization", "Bearer " + accessToken)
-                .body(Resp.ok("성공적으로 로그인 되었습니다."));
+                .body(Resp.ok(result, "성공적으로 로그인 되었습니다."));
     }
 
     // 로그아웃

--- a/src/main/java/green/mtcoding/bookbox/admin/AdminController.java
+++ b/src/main/java/green/mtcoding/bookbox/admin/AdminController.java
@@ -23,13 +23,13 @@ public class AdminController {
 
     // =========================== AUTH ====================================
 
-    // 자동 로그인
-    @PostMapping("/api/admins/auto/login")
-    public ResponseEntity<?> autoLogin(HttpServletRequest request) {
-        String accessToken = request.getHeader("Authorization");
-        AdminResponse.LoginDTO responseDTO = adminService.자동로그인(accessToken);
-        return ResponseEntity.ok(Resp.ok(responseDTO));
-    }
+//    // 자동 로그인
+//    @PostMapping("/api/admins/auto/login")
+//    public ResponseEntity<?> autoLogin(HttpServletRequest request) {
+//        String accessToken = request.getHeader("Authorization");
+//        AdminResponse.LoginDTO responseDTO = adminService.자동로그인(accessToken);
+//        return ResponseEntity.ok(Resp.ok(responseDTO));
+//    }
 
     // 로그인
     @PostMapping("/api/admins/login")
@@ -50,12 +50,22 @@ public class AdminController {
         return ResponseEntity.ok(Resp.ok("로그아웃이 완료되었습니다."));
     }
 
-    // 전체 유저 목록 조회
+    // 전체 유저 목록 조회 (유저 정보만)
     @GetMapping("/api/admins/user-list")
     public ResponseEntity<?> getUserList() {
         List<UserResponse.UserDTO> users = adminService.getUserList();
         return ResponseEntity.ok(Resp.ok(users));
     }
+
+
+    // 특정 유저의 예약 및 대여 목록 조회
+    @GetMapping("/api/admins/user-detail/{id}")
+    public ResponseEntity<?> getUserDetails(@PathVariable Long id) {
+        UserResponse.UserDetailsDTO userDetails = adminService.getUserDetails(id);
+        return ResponseEntity.ok(Resp.ok(userDetails));
+    }
+
+
 
 
     // =========================== BOOK ====================================

--- a/src/main/java/green/mtcoding/bookbox/admin/AdminController.java
+++ b/src/main/java/green/mtcoding/bookbox/admin/AdminController.java
@@ -5,6 +5,8 @@ import green.mtcoding.bookbox.book.BookResponse;
 import green.mtcoding.bookbox.book.BookService;
 import green.mtcoding.bookbox.core.util.Resp;
 import green.mtcoding.bookbox.user.UserRequest;
+import green.mtcoding.bookbox.user.UserResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,15 +22,25 @@ public class AdminController {
     private final BookService bookService;
 
     // =========================== AUTH ====================================
+
+    // 자동 로그인
+    @PostMapping("/api/admins/auto/login")
+    public ResponseEntity<?> autoLogin(HttpServletRequest request) {
+        String accessToken = request.getHeader("Authorization");
+        AdminResponse.LoginDTO responseDTO = adminService.자동로그인(accessToken);
+        return ResponseEntity.ok(Resp.ok(responseDTO));
+    }
+
     // 로그인
     @PostMapping("/api/admins/login")
     public ResponseEntity<?> login(@RequestBody AdminRequest.LoginDTO loginDTO) {
         AdminResponse.LoginDTO result = adminService.로그인(loginDTO);
-        String accessToken = result.getToken();
+        String accessToken = result.getToken(); // 토큰 생성
 
+        // JWT 토큰을 헤더에 포함시켜서 응답
         return ResponseEntity.ok()
                 .header("Authorization", "Bearer " + accessToken)
-                .body(Resp.ok(result, "성공적으로 로그인 되었습니다."));
+                .body(Resp.ok("성공적으로 로그인 되었습니다."));
     }
 
     // 로그아웃
@@ -41,7 +53,7 @@ public class AdminController {
     // 전체 유저 목록 조회
     @GetMapping("/api/admins/user-list")
     public ResponseEntity<?> getUserList() {
-        List<UserRequest.UserDTO> users = adminService.getUserList();
+        List<UserResponse.UserDTO> users = adminService.getUserList();
         return ResponseEntity.ok(Resp.ok(users));
     }
 

--- a/src/main/java/green/mtcoding/bookbox/admin/AdminService.java
+++ b/src/main/java/green/mtcoding/bookbox/admin/AdminService.java
@@ -14,6 +14,7 @@ import green.mtcoding.bookbox.user.UserRepository;
 import green.mtcoding.bookbox.user.UserRequest;
 import green.mtcoding.bookbox.user.UserResponse;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -30,24 +31,24 @@ public class AdminService {
     private final BookRepository bookRepository;
 
     // =========================== AUTH ====================================
-    // 자동 로그인 로직
-    public AdminResponse.LoginDTO 자동로그인(String accessToken) {
-
-        Optional.ofNullable(accessToken).orElseThrow(() -> new ExceptionApi400("토큰을 찾을 수 없습니다."));
-        try {
-            Admin admin = JwtUtil.verifyAdminToken(accessToken);
-            Admin adminPS = adminRepository.findById(admin.getId())
-                    .orElseThrow(() -> new ExceptionApi400("관리자를 찾을 수 없습니다."));
-            return AdminResponse.LoginDTO.builder()
-                    .id(adminPS.getId())
-                    .username(adminPS.getUsername())
-                    .build();
-        } catch (SignatureVerificationException | JWTDecodeException e1) {
-            throw new ExceptionApi400("유효하지 않은 토큰입니다.");
-        } catch (TokenExpiredException e2) {
-            throw new ExceptionApi400("토큰이 만료되었습니다.");
-        }
-    }
+//    // 자동 로그인 로직
+//    public AdminResponse.LoginDTO 자동로그인(String accessToken) {
+//
+//        Optional.ofNullable(accessToken).orElseThrow(() -> new ExceptionApi400("토큰을 찾을 수 없습니다."));
+//        try {
+//            Admin admin = JwtUtil.verifyAdminToken(accessToken);
+//            Admin adminPS = adminRepository.findById(admin.getId())
+//                    .orElseThrow(() -> new ExceptionApi400("관리자를 찾을 수 없습니다."));
+//            return AdminResponse.LoginDTO.builder()
+//                    .id(adminPS.getId())
+//                    .username(adminPS.getUsername())
+//                    .build();
+//        } catch (SignatureVerificationException | JWTDecodeException e1) {
+//            throw new ExceptionApi400("유효하지 않은 토큰입니다.");
+//        } catch (TokenExpiredException e2) {
+//            throw new ExceptionApi400("토큰이 만료되었습니다.");
+//        }
+//    }
 
     // 로그인 로직
     public AdminResponse.LoginDTO 로그인(AdminRequest.LoginDTO request) {
@@ -80,13 +81,27 @@ public class AdminService {
                 .build();
     }
 
-    // 전체 유저 목록 조회
+    // 전체 유저 목록 조회 (유저 정보만)
     @Transactional
     public List<UserResponse.UserDTO> getUserList() {
         List<User> users = userRepository.findAll();
         return users.stream()
                 .map(UserResponse.UserDTO::new)
                 .collect(Collectors.toList());
+    }
+
+    // 특정 유저의 예약 및 대여 목록 조회
+    @Transactional
+    public UserResponse.UserDetailsDTO getUserDetails(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionApi400("해당 유저를 찾을 수 없습니다."));
+
+        // Lazy 로딩 된 대여 및 예약 목록을 명시적으로 초기화
+        Hibernate.initialize(user.getLends());
+        Hibernate.initialize(user.getReservations());
+
+        // 유저의 예약 및 대여 목록을 함께 반환
+        return new UserResponse.UserDetailsDTO(user);
     }
 
 

--- a/src/main/java/green/mtcoding/bookbox/reservation/ReservationRequest.java
+++ b/src/main/java/green/mtcoding/bookbox/reservation/ReservationRequest.java
@@ -2,12 +2,21 @@ package green.mtcoding.bookbox.reservation;
 
 import lombok.Data;
 
+import java.sql.Timestamp;
+
 public class ReservationRequest {
 
-    @Data
-    public static class ReservationDTO {
-        private Long userId;
-        private String isbn13;
-    }
+//    @Data
+//    public static class ReservationDTO {
+//        private Long id;
+//        private String isbn13;
+//        private Timestamp reservationDate;
+//
+//        public ReservationDTO(Reservation reservation) {
+//            this.id = reservation.getId();
+//            this.isbn13 = reservation.getBook().getTitle();
+//            this.reservationDate = reservation.getReservationDate();
+//        }
+//    }
 
 }

--- a/src/main/java/green/mtcoding/bookbox/reservation/ReservationResponse.java
+++ b/src/main/java/green/mtcoding/bookbox/reservation/ReservationResponse.java
@@ -2,20 +2,25 @@ package green.mtcoding.bookbox.reservation;
 
 import lombok.Data;
 
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 public class ReservationResponse {
 
     @Data
     public static class ReservationDTO {
+        private Long id;
         private String bookTitle;
-        private LocalDateTime reservationDate;
+        private Timestamp reservationDate; // TODO: LocalDateTime에서 Timestamp로 변경했는데 2개의 차이
         private int sequence;
 
-        public ReservationDTO(String bookTitle, LocalDateTime reservationDate, int sequence) {
-            this.bookTitle = bookTitle;
-            this.reservationDate = reservationDate;
-            this.sequence = sequence;
+
+        public ReservationDTO(Reservation reservation) {
+            this.id = reservation.getId();
+            this.bookTitle = reservation.getBook().getTitle();
+            this.reservationDate = reservation.getReservationDate();
+            this.sequence = reservation.getSequence();
+
         }
     }
 }

--- a/src/main/java/green/mtcoding/bookbox/reservation/ReservationService.java
+++ b/src/main/java/green/mtcoding/bookbox/reservation/ReservationService.java
@@ -65,11 +65,7 @@ public class ReservationService {
 
         reservationRepository.save(reservation);
 
-        return new ReservationResponse.ReservationDTO (
-            reservation.getBook().getTitle(),
-            reservation.getReservationDate().toLocalDateTime(),
-            reservation.getSequence()
-        );
+        return new ReservationResponse.ReservationDTO(reservation);
 
     }
 
@@ -108,11 +104,7 @@ public class ReservationService {
         User user = userRepository.findById(userId).orElseThrow(() -> new ExceptionApi400("유저를 찾을 수 없습니다."));
         List<Reservation> reservations = reservationRepository.findByUser(user);
         return reservations.stream()
-                .map(reservation -> new ReservationResponse.ReservationDTO(
-                        reservation.getBook().getTitle(),
-                        reservation.getReservationDate().toLocalDateTime(),
-                        reservation.getSequence()
-                ))
+                .map(reservation -> new ReservationResponse.ReservationDTO(reservation))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/green/mtcoding/bookbox/user/UserRepository.java
+++ b/src/main/java/green/mtcoding/bookbox/user/UserRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -17,4 +18,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("select u from User u where u.username=:username and u.password=:password")
     Optional<User> findByUsernameAndPassword(@Param("username") String username, @Param("password") String password);
+
 }

--- a/src/main/java/green/mtcoding/bookbox/user/UserRequest.java
+++ b/src/main/java/green/mtcoding/bookbox/user/UserRequest.java
@@ -41,22 +41,4 @@ public class UserRequest {
         private String password;
     }
 
-    // TODO: 유저의 기본 정보와 필요 데이터 응답을 위해 생성 - 신민재
-    @Data
-    public static class UserDTO {
-        private Long id;
-        private String username;
-        private String email;
-        private String phone;
-
-
-        // 매개변수로 받음
-        public UserDTO(User user) {
-            this.id = user.getId();
-            this.username = user.getUsername();
-            this.email = user.getEmail();
-            this.phone = user.getPhone();
-        }
-    }
-
 }

--- a/src/main/java/green/mtcoding/bookbox/user/UserResponse.java
+++ b/src/main/java/green/mtcoding/bookbox/user/UserResponse.java
@@ -1,6 +1,8 @@
 package green.mtcoding.bookbox.user;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import green.mtcoding.bookbox.lend.LendResponse;
+import green.mtcoding.bookbox.reservation.ReservationResponse;
 import lombok.Builder;
 import lombok.Data;
 
@@ -49,6 +51,31 @@ public class UserResponse {
             this.accessToken = accessToken;
         }
     }
+
+
+    // TODO: 유저의 기본 정보와 필요 데이터 응답을 위해 생성 - 신민재
+    // 대여, 예약 목록 추가
+    @Data
+    public static class UserDTO {
+        private Long id;
+        private String username;
+        private String nick;
+        private String email;
+        private String phone;
+        private List<LendResponse.LendDTO> lends;
+        private List<ReservationResponse.ReservationDTO> reservations;
+
+        public UserDTO(User user) {
+            this.id = user.getId();
+            this.username = user.getUsername();
+            this.nick = user.getNick();
+            this.email = user.getEmail();
+            this.phone = user.getPhone();
+            this.lends = user.getLends().stream().map(LendResponse.LendDTO::new).collect(Collectors.toList());
+            this.reservations = user.getReservations().stream().map(ReservationResponse.ReservationDTO::new).collect(Collectors.toList());
+        }
+    }
+
 
     // 조회
     @Data

--- a/src/main/java/green/mtcoding/bookbox/user/UserResponse.java
+++ b/src/main/java/green/mtcoding/bookbox/user/UserResponse.java
@@ -6,6 +6,11 @@ import green.mtcoding.bookbox.reservation.ReservationResponse;
 import lombok.Builder;
 import lombok.Data;
 
+import javax.swing.text.View;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class UserResponse {
     // 회원가입
     @Data
@@ -54,7 +59,8 @@ public class UserResponse {
 
 
     // TODO: 유저의 기본 정보와 필요 데이터 응답을 위해 생성 - 신민재
-    // 대여, 예약 목록 추가
+
+    // 유저 기본 정보들
     @Data
     public static class UserDTO {
         private Long id;
@@ -62,8 +68,6 @@ public class UserResponse {
         private String nick;
         private String email;
         private String phone;
-        private List<LendResponse.LendDTO> lends;
-        private List<ReservationResponse.ReservationDTO> reservations;
 
         public UserDTO(User user) {
             this.id = user.getId();
@@ -71,8 +75,55 @@ public class UserResponse {
             this.nick = user.getNick();
             this.email = user.getEmail();
             this.phone = user.getPhone();
-            this.lends = user.getLends().stream().map(LendResponse.LendDTO::new).collect(Collectors.toList());
-            this.reservations = user.getReservations().stream().map(ReservationResponse.ReservationDTO::new).collect(Collectors.toList());
+        }
+    }
+
+    // 특정 유저의 예약 및 대여 목록
+    @Data
+    public static class UserDetailsDTO {
+        private Long id;
+        private String username;
+        private String nick;
+        private List<LendDTO> lends;  // 대여 목록
+        private List<ReservationDTO> reservations;  // 예약 목록
+
+        // 예약 및 대여 목록을 포함한 생성자
+        public UserDetailsDTO(User user) {
+            this.id = user.getId();
+            this.username = user.getUsername();
+            this.nick = user.getNick();
+
+            // 대여 목록 매핑
+            this.lends = user.getLends().stream()
+                    .map(lend -> new LendDTO(lend.getBook().getTitle(), lend.getLendDate()))
+                    .collect(Collectors.toList());
+
+            // 예약 목록 매핑
+            this.reservations = user.getReservations().stream()
+                    .map(reservation -> new ReservationDTO(reservation.getBook().getTitle(), reservation.getReservationDate()))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Data
+    public static class LendDTO {
+        private String bookTitle;
+        private Timestamp lendDate;
+
+        public LendDTO(String bookTitle, Timestamp lendDate) {
+            this.bookTitle = bookTitle;
+            this.lendDate = lendDate;
+        }
+    }
+
+    @Data
+    public static class ReservationDTO {
+        private String bookTitle;
+        private Timestamp reservationDate;
+
+        public ReservationDTO(String bookTitle, Timestamp reservationDate) {
+            this.bookTitle = bookTitle;
+            this.reservationDate = reservationDate;
         }
     }
 

--- a/src/main/java/green/mtcoding/bookbox/user/UserService.java
+++ b/src/main/java/green/mtcoding/bookbox/user/UserService.java
@@ -72,18 +72,6 @@ public class UserService {
     }
 
 
-    // 회원 목록 조회(유저의 대여 목록과 예약 목록 함께 return) TODO: 신민재
-    public List<UserResponse.UserDTO> getUserList() {
-        List<User> users = userRepository.findAll();
-        return users.stream()
-                .map(UserResponse.UserDTO::new)
-                .collect(Collectors.toList());
-    }
-
-
-
-
-
 
 /*    public User 회원탈퇴(Long id) {
         // 조회

--- a/src/main/java/green/mtcoding/bookbox/user/UserService.java
+++ b/src/main/java/green/mtcoding/bookbox/user/UserService.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -67,6 +69,15 @@ public class UserService {
         String accessToken = JwtUtil.createUserToken(user);
 
         return new UserResponse.LoginDTO(user, accessToken);
+    }
+
+
+    // 회원 목록 조회(유저의 대여 목록과 예약 목록 함께 return) TODO: 신민재
+    public List<UserResponse.UserDTO> getUserList() {
+        List<User> users = userRepository.findAll();
+        return users.stream()
+                .map(UserResponse.UserDTO::new)
+                .collect(Collectors.toList());
     }
 
 


### PR DESCRIPTION
### 특정 유저의 대여&예약 목록 조회는 테스트 시 사진과 같은 오류 발생
![스크린샷 2024-10-16 15 48 24](https://github.com/user-attachments/assets/21125da5-71d4-46c3-a5b1-249a79e15130)

<br>
fetch 전략 수정 필요, 프론트 데이터 바인딩으로 인해 해당 기능 잠시 보류